### PR TITLE
parse_perforce_path() takes two arguments

### DIFF
--- a/bin/convert_logs.py
+++ b/bin/convert_logs.py
@@ -123,7 +123,7 @@ def main(argv):
         parser = parse_gnu_changelog
     elif opts.perforce_path:
         #special case
-        create_event_xml(parse_perforce_path(opts.perforce_path), output)
+        create_event_xml(parse_perforce_path(opts.perforce_path, opts), output)
         return
     else:
         print >>stderr, "No repository format given, for more info see:\n   convert_logs.py --help"


### PR DESCRIPTION
Analyzing Perforce repositories was broken:

<pre>
$ bin/convert_logs.py --perforce-path blah
Traceback (most recent call last):
  File "bin/convert_logs.py", line 513, in <module>
    main(sys.argv)
  File "bin/convert_logs.py", line 126, in main
    create_event_xml(parse_perforce_path(opts.perforce_path), output)
TypeError: parse_perforce_path() takes exactly 2 arguments (1 given)
</pre>
