### PR TITLE
Calculate root path when `code_swarm` is a symbolic link

### DIFF
--- a/bin/code_swarm
+++ b/bin/code_swarm
@@ -96,9 +96,8 @@ def main():
 
 def root_path():
     "Returns the path of the code_swarm source directory"
-    path = os.path.dirname(__file__)
-    path = os.path.dirname(path)
-    return path
+    real_path = os.path.join(os.path.dirname(__file__), os.readlink(__file__))
+    return os.path.dirname(real_path)
 
 
 def invoke_code_swarm(code_swarm_jar, proj_cfg, options):


### PR DESCRIPTION
If `code_swarm` is a symbolic link, the script currently resolves the `root_path()` as the directory containing the link. This makes it difficult to link to the `code_swarm` binary from, e.g., a directory on the `$PATH` (such as `/usr/local/bin`). This patch finds the "real path" for a symlink and uses the directory of the target to calculate the `root_path()`.
