### PR TITLE
Add missing argument in os.path.islink()

### DIFF
--- a/bin/code_swarm
+++ b/bin/code_swarm
@@ -95,9 +95,9 @@ def main():
 
 
 def root_path():
-    "Returns the path of the code_swarm source directory"
+    """Returns the path of the code_swarm source directory"""
     real_file = __file__
-    if os.path.islink():
+    if os.path.islink(__file__):
         real_file = os.readlink(__file__)
 
     real_path = os.path.join(os.path.dirname(real_file))


### PR DESCRIPTION
Hi,

The python script was throwing a `TypeError`, adding `__file__` as an argument fixed it for me.

``` python
Traceback (most recent call last):
  File "/Users/corentin/project/perso/code_swarm/bin/code_swarm", line 249, in <module>
    main()
  File "/Users/corentin/project/perso/code_swarm/bin/code_swarm", line 76, in main
    proj_cfg = autogenerate_files(options)
  File "/Users/corentin/project/perso/code_swarm/bin/code_swarm", line 185, in autogenerate_files
    cp_tpl = os.path.join(root_path(), "bin", "config.template")
  File "/Users/corentin/project/perso/code_swarm/bin/code_swarm", line 100, in root_path
    if os.path.islink():
TypeError: islink() takes exactly 1 argument (0 given)
```
